### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,7 @@ A fast & minimal embedded full-text indexing library, written in Objective-C, bu
 
 By far, the easiest way to integrate this library in your project is by using [CocoaPods][1].
 
-1. Have [Cocoapods][1] installed, if you don't already
+1. Have [CocoaPods][1] installed, if you don't already
 
 2. In your Podfile, add the line
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
